### PR TITLE
feat: allow named imports

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -94,10 +94,12 @@ export type FuzzySearcher<T> = (string) => Array<FuzzyResult<T>>
  *
  * If you use React, use `useFuzzySearchList` hook for convenience.
  */
-export default function createFuzzySearch<Element>(
+export function createFuzzySearch<Element>(
   list: Element[],
   options?: FuzzySearchOptions,
 ): FuzzySearcher<Element>
+
+export default createFuzzySearch
 
 /**
  * Runs a one-off fuzzy search matching on `text` against `queryText`.

--- a/src/index.js
+++ b/src/index.js
@@ -96,12 +96,14 @@ export type FuzzySearcher<T> = (string) => Array<FuzzyResult<T>>
  *
  * If you use React, use `useFuzzySearchList` hook for convenience.
  */
-export default function createFuzzySearch<Element>(
+export function createFuzzySearch<Element>(
   list: Element[],
   options?: FuzzySearchOptions = ({}: any),
 ): FuzzySearcher<Element> {
   return require('./impl').createFuzzySearchImpl(list, options)
 }
+
+export default createFuzzySearch
 
 /**
  * Runs a one-off fuzzy search matching on `text` against `queryText`.


### PR DESCRIPTION
Due to compatibility issues between CommonJS modules and ES modules regarding default exports (https://github.com/evanw/esbuild/issues/1719#issuecomment-953470495), I have provided a way to allow the library consumer to use named imports instead.